### PR TITLE
Add manual focus control

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -295,6 +295,10 @@
         <input id="contrast" type='range' min='-50' max='50' step='10' value='0'
           oninput='getElById("contVal").innerText=this.value;fetch("/?contrast="+this.value)'>
 
+        <label for="focus">Focus <span class='val-badge' id='focusVal'>Auto</span></label>
+        <input id="focus" type='range' min='-1' max='1' step='0.05' value='-1'
+          oninput='getElById("focusVal").innerText=(parseFloat(this.value)<0?"Auto":parseFloat(this.value).toFixed(2));fetch("/?focus_distance="+this.value)'>
+
 
         <label for="delay">Frame Delay (ms)</label>
         <input id="delay" type='number' min='10' max='1000' value='33'

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
@@ -460,6 +460,7 @@ class StreamingService : LifecycleService() {
         val p = PreferenceManager.getDefaultSharedPreferences(this); val id = camId()
         p.getString("exposure_$id", null)?.toIntOrNull()?.let { b.setExposure(it) }
         p.getString("zoom_$id", null)?.toFloatOrNull()?.let { b.setZoom(it) }
+        p.getString("focus_$id", null)?.toFloatOrNull()?.let { b.setManualFocus(it) }
     }
 
     // ---------------- snapshot (full resolution) ----------------
@@ -576,7 +577,8 @@ class StreamingService : LifecycleService() {
 
     /**
      * GET /?<key>=<value> (proxied as /api/video/control):
-     *   torch=on|off|toggle   focus=1   exposure=<ev>   zoom=<ratio>
+     *   torch=on|off|toggle   focus=1|auto|continuous   focus_distance=<0..1|-1>
+     *   exposure=<ev>   zoom=<ratio>
      *   camera=<id>|front|back|toggle   resolution=WxH   api=auto|camerax|camera1
      */
     private fun handleRemoteControl(key: String, value: String) {
@@ -603,7 +605,22 @@ class StreamingService : LifecycleService() {
                 prefs.edit().putString("zoom_$id", z.toString()).apply()
                 launchMain { backend?.setZoom(z) }
             }
-            "focus" -> launchMain { backend?.triggerAutoFocus() }
+            "focus" -> when (value.lowercase()) {
+                "continuous", "auto" -> {
+                    prefs.edit().remove("focus_$id").apply()
+                    launchMain { backend?.setManualFocus(-1f) }
+                }
+                else -> {   // focus=1: one-shot autofocus supersedes any fixed focus
+                    prefs.edit().remove("focus_$id").apply()
+                    launchMain { backend?.triggerAutoFocus() }
+                }
+            }
+            "focus_distance" -> {
+                val f = value.toFloatOrNull() ?: return
+                if (f < 0f) prefs.edit().remove("focus_$id").apply()
+                else prefs.edit().putString("focus_$id", f.coerceIn(0f, 1f).toString()).apply()
+                launchMain { backend?.setManualFocus(f) }
+            }
             "camera" -> {
                 val keepTorchOn = backend?.getTorch() == true
                 val target = resolveCamera(value) ?: return

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/Camera1Capture.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/Camera1Capture.kt
@@ -137,6 +137,31 @@ class Camera1Capture(private val cameraId: Int, targetW: Int, targetH: Int) : Ca
         } catch (e: Exception) { Log.e(TAG, "AF: ${e.message}") }
     }
 
+    /**
+     * Best-effort manual focus. The Camera1 API has no focus-distance control, so this only maps to
+     * coarse modes (no gradation across the 0..1 range): [distance] < 0 restores continuous AF;
+     * ~0 uses INFINITY (far); any other value uses FIXED — the lens' fixed factory position (often
+     * hyperfocal/infinity), not the current AF position — where the hardware supports it.
+     */
+    override fun setManualFocus(distance: Float) = live { p ->
+        val modes = p.supportedFocusModes
+        if (distance < 0f) {
+            listOf(Camera.Parameters.FOCUS_MODE_CONTINUOUS_VIDEO, Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE)
+                .firstOrNull { modes?.contains(it) == true }?.let { p.focusMode = it }
+        } else {
+            val mode = when {
+                distance <= 0.05f && modes?.contains(Camera.Parameters.FOCUS_MODE_INFINITY) == true ->
+                    Camera.Parameters.FOCUS_MODE_INFINITY
+                modes?.contains(Camera.Parameters.FOCUS_MODE_FIXED) == true ->
+                    Camera.Parameters.FOCUS_MODE_FIXED
+                modes?.contains(Camera.Parameters.FOCUS_MODE_INFINITY) == true ->
+                    Camera.Parameters.FOCUS_MODE_INFINITY
+                else -> null
+            }
+            mode?.let { p.focusMode = it }
+        }
+    }
+
     private fun live(block: (Camera.Parameters) -> Unit) {
         try { val p = camera.parameters; block(p); camera.parameters = p } catch (_: Exception) {}
     }

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/CameraXCapture.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/CameraXCapture.kt
@@ -3,12 +3,15 @@ package com.github.digitallyrefined.androidipcamera.helpers
 import android.content.Context
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CameraMetadata
 import android.hardware.camera2.CaptureRequest
 import android.util.Log
 import android.util.Range
 import android.util.Size
-import androidx.camera.camera2.interop.Camera2Interop
+import androidx.camera.camera2.interop.Camera2CameraControl
 import androidx.camera.camera2.interop.Camera2CameraInfo
+import androidx.camera.camera2.interop.Camera2Interop
+import androidx.camera.camera2.interop.CaptureRequestOptions
 import androidx.camera.camera2.interop.ExperimentalCamera2Interop
 import androidx.camera.core.AspectRatio
 import androidx.camera.core.CameraSelector
@@ -54,6 +57,8 @@ class CameraXCapture(
     private var camera: androidx.camera.core.Camera? = null
     private var imageCapture: ImageCapture? = null
     @Volatile private var torchEnabled = false
+    // Cached manual focus (0f..1f) so it can be re-applied after an async (re)bind; null = autofocus.
+    @Volatile private var manualFocus: Float? = null
     private val main = ContextCompat.getMainExecutor(ctx)
     private val analysisExec = Executors.newSingleThreadExecutor()
 
@@ -116,6 +121,8 @@ class CameraXCapture(
                 if (torchEnabled) {
                     try { camera?.cameraControl?.enableTorch(true) } catch (_: Exception) {}
                 }
+                // setManualFocus() may be called before bind completes; re-apply cached value now.
+                manualFocus?.let { setManualFocus(it) }
                 ready = true
                 Log.i(TAG, "bound desired ${desired.width}x${desired.height} front=$front cameraId=${cameraId ?: "default"}")
             } catch (e: Exception) { Log.e(TAG, "start: ${e.message}") }
@@ -140,14 +147,49 @@ class CameraXCapture(
     override fun setTorch(on: Boolean) { torchEnabled = on; try { camera?.cameraControl?.enableTorch(on) } catch (_: Exception) {} }
     override fun setExposure(ev: Int) { try { camera?.cameraControl?.setExposureCompensationIndex(ev) } catch (_: Exception) {} }
     override fun setZoom(ratio: Float) { try { camera?.cameraControl?.setZoomRatio(ratio) } catch (_: Exception) {} }
+    @OptIn(ExperimentalCamera2Interop::class)
     override fun triggerAutoFocus() {
         try {
             val cam = camera ?: return
+            // Drop any manual-focus override, else the lingering CONTROL_AF_MODE_OFF
+            // defeats the AF scan below.
+            manualFocus = null
+            try { Camera2CameraControl.from(cam.cameraControl).clearCaptureRequestOptions() } catch (_: Exception) {}
             val pt = SurfaceOrientedMeteringPointFactory(1f, 1f).createPoint(0.5f, 0.5f)
             cam.cameraControl.startFocusAndMetering(
                 FocusMeteringAction.Builder(pt, FocusMeteringAction.FLAG_AF or FocusMeteringAction.FLAG_AE)
                     .setAutoCancelDuration(3, TimeUnit.SECONDS).build())
         } catch (e: Exception) { Log.e(TAG, "AF: ${e.message}") }
+    }
+
+    /**
+     * Fixed manual focus via Camera2 interop. [distance] 0f..1f maps to LENS_FOCUS_DISTANCE
+     * in diopters (0f = infinity, 1f = the lens' minimum focus distance / nearest). A negative
+     * value clears the override and restores continuous autofocus.
+     */
+    @OptIn(ExperimentalCamera2Interop::class)
+    override fun setManualFocus(distance: Float) {
+        val cam = camera ?: run { manualFocus = distance.takeIf { it >= 0f }; return }
+        try {
+            val c2 = Camera2CameraControl.from(cam.cameraControl)
+            if (distance < 0f) {
+                // Clear the override so CameraX resumes its own continuous AF.
+                manualFocus = null
+                c2.clearCaptureRequestOptions()
+                return
+            }
+            val norm = distance.coerceIn(0f, 1f)
+            manualFocus = norm
+            // Nearest focus in diopters; 0f (fixed-focus lens) leaves us at infinity, which is fine.
+            val minDist = Camera2CameraInfo.from(cam.cameraInfo)
+                .getCameraCharacteristic(CameraCharacteristics.LENS_INFO_MINIMUM_FOCUS_DISTANCE) ?: 0f
+            c2.captureRequestOptions = CaptureRequestOptions.Builder()
+                .setCaptureRequestOption(
+                    CaptureRequest.CONTROL_AF_MODE, CameraMetadata.CONTROL_AF_MODE_OFF)
+                .setCaptureRequestOption(
+                    CaptureRequest.LENS_FOCUS_DISTANCE, norm * minDist)
+                .build()
+        } catch (e: Exception) { Log.e(TAG, "manualFocus: ${e.message}") }
     }
 
     /** The camera's WIDEST advertised AE FPS range — leaves auto-exposure fully free while giving legacy

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/CaptureBackend.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/CaptureBackend.kt
@@ -17,5 +17,11 @@ interface CaptureBackend {
     fun setExposure(ev: Int)
     fun setZoom(ratio: Float)
     fun triggerAutoFocus()
+    /**
+     * Manual focus. [distance] in 0f..1f is a normalized fixed focus distance
+     * (0f = far/infinity, 1f = nearest). A negative value returns the camera to
+     * continuous autofocus. Backends apply this on a best-effort basis.
+     */
+    fun setManualFocus(distance: Float)
     fun stop()
 }


### PR DESCRIPTION
Adds a fixed manual focus option alongside the existing autofocus trigger.

- **CaptureBackend**: new `setManualFocus(distance)` (0f..1f = fixed distance, negative = restore continuous autofocus)
- **CameraXCapture**: implemented via Camera2 interop (`CONTROL_AF_MODE_OFF` + `LENS_FOCUS_DISTANCE`), cached and re-applied after async (re)bind
- **Camera1Capture**: best-effort mapping to FIXED / INFINITY focus modes
- **StreamingService**: new `focus_distance=<0..1|-1>` remote control param; `focus=1` still triggers one-shot autofocus, `focus=continuous` restores AF; value persisted per-camera and restored on start
- **Web UI**: Focus slider (Auto at -1, fixed 0..1) in the controls panel

Built with `assembleDebug` and tested on a physical device — works as expected.


**AI warning: This PR and Code was created via claude code!**

It was tested and verified by me on my POCO F7 Pro