### PR TITLE
Fix slider controls (ordered updates) and group camera vs post-processing controls

### DIFF
--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -171,6 +171,15 @@
       margin-bottom: 15px;
     }
 
+    .group-title {
+      font-size: 12px;
+      color: #aaa;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-weight: bold;
+      margin: 22px 0 14px;
+    }
+
     label {
       display: block;
       margin-bottom: 5px;
@@ -206,21 +215,6 @@
       color: #555;
       font-size: 11px;
       text-align: center;
-    }
-
-    .group-title {
-      font-size: 12px;
-      color: #aaa;
-      text-transform: uppercase;
-      letter-spacing: 1px;
-      font-weight: bold;
-      margin: 22px 0 2px;
-    }
-
-    .group-hint {
-      color: #666;
-      font-size: 11px;
-      margin: 0 0 14px;
     }
 
     @media (max-width: 900px) {
@@ -288,7 +282,6 @@
         </div>
 
         <p class="group-title">Camera Control</p>
-        <p class="group-hint">Adjusts the actual camera hardware (sensor &amp; lens) &mdash; not a digital effect.</p>
 
         <label for="resolutionSelect">Resolution</label>
         <select id="resolutionSelect" style="margin-bottom: 20px" onchange='fetch("/?resolution="+this.value)'>
@@ -306,7 +299,6 @@
           data-control='exposure' data-badge='exposureVal'>
 
         <p class="group-title">Post Processing</p>
-        <p class="group-hint">Applied to the video stream after capture (digital, does not touch the camera).</p>
 
         <label for="scale">Scale <span class='val-badge' id='scaleVal'>1.0x</span></label>
         <input id="scale" type='range' min='0.5' max='2.0' step='0.1' value='1.0'

--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -208,6 +208,21 @@
       text-align: center;
     }
 
+    .group-title {
+      font-size: 12px;
+      color: #aaa;
+      text-transform: uppercase;
+      letter-spacing: 1px;
+      font-weight: bold;
+      margin: 22px 0 2px;
+    }
+
+    .group-hint {
+      color: #666;
+      font-size: 11px;
+      margin: 0 0 14px;
+    }
+
     @media (max-width: 900px) {
       .main {
         flex-direction: column;
@@ -269,8 +284,11 @@
 
           <label for="audioGain">Audio Gain <span class='val-badge' id='audioGainVal'>1.0</span></label>
           <input id="audioGain" type='range' min='0.5' max='3.0' step='0.1' value='1.0'
-            oninput='getElById("audioGainVal").innerText=this.value;fetch("/?audio_gain="+this.value)'>
+            data-control='audio_gain' data-badge='audioGainVal'>
         </div>
+
+        <p class="group-title">Camera Control</p>
+        <p class="group-hint">Adjusts the actual camera hardware (sensor &amp; lens) &mdash; not a digital effect.</p>
 
         <label for="resolutionSelect">Resolution</label>
         <select id="resolutionSelect" style="margin-bottom: 20px" onchange='fetch("/?resolution="+this.value)'>
@@ -281,20 +299,22 @@
 
         <label for="zoom">Zoom <span class='val-badge' id='zoomVal'>1.0x</span></label>
         <input id="zoom" type='range' min='1' max='8' step='0.1' value='1.0'
-          oninput='getElById("zoomVal").innerText=this.value+"x";fetch("/?zoom="+this.value)'>
-
-        <label for="scale">Scale <span class='val-badge' id='scaleVal'>1.0x</span></label>
-        <input id="scale" type='range' min='0.5' max='2.0' step='0.1' value='1.0'
-          oninput='setView("original"); getElById("scaleVal").innerText=this.value+"x";fetch("/?scale="+this.value)'>
+          data-control='zoom' data-badge='zoomVal' data-fmt='suffix' data-suffix='x'>
 
         <label for="exposure">Exposure <span class='val-badge' id='exposureVal'>0</span></label>
         <input id="exposure" type='range' min='-10' max='10' step='1' value='0'
-          oninput='getElById("exposureVal").innerText=this.value;fetch("/?exposure="+this.value)'>
+          data-control='exposure' data-badge='exposureVal'>
+
+        <p class="group-title">Post Processing</p>
+        <p class="group-hint">Applied to the video stream after capture (digital, does not touch the camera).</p>
+
+        <label for="scale">Scale <span class='val-badge' id='scaleVal'>1.0x</span></label>
+        <input id="scale" type='range' min='0.5' max='2.0' step='0.1' value='1.0'
+          data-control='scale' data-badge='scaleVal' data-fmt='suffix' data-suffix='x' data-setview='original'>
 
         <label for="contrast">Contrast <span class='val-badge' id='contVal'>0</span></label>
         <input id="contrast" type='range' min='-50' max='50' step='10' value='0'
-          oninput='getElById("contVal").innerText=this.value;fetch("/?contrast="+this.value)'>
-
+          data-control='contrast' data-badge='contVal'>
 
         <label for="delay">Frame Delay (ms)</label>
         <input id="delay" type='number' min='10' max='1000' value='33'
@@ -434,6 +454,67 @@
       avDelayVal.textContent = `${avDelay.value}s`;
       videoDelayMs = Math.max(0, (parseFloat(avDelay.value) || 0) * 1000);
     }
+
+    // Live preview while dragging, but throttled; each request carries an
+    // increasing timestamp so the server can drop out-of-order updates.
+    const CONTROL_THROTTLE_MS = 100;
+    let lastControlTs = 0;
+    function nextControlTs() {
+      // Wall-clock based, but never repeats within the same millisecond.
+      lastControlTs = Math.max(Date.now(), lastControlTs + 1);
+      return lastControlTs;
+    }
+
+    function formatControlValue(el) {
+      const v = el.value;
+      switch (el.dataset.fmt) {
+        case 'suffix':
+          return v + (el.dataset.suffix || '');
+        case 'focus': {
+          const n = parseFloat(v);
+          return n < 0 ? 'Auto' : n.toFixed(2);
+        }
+        default:
+          return v;
+      }
+    }
+
+    function bindControl(el) {
+      const param = el.dataset.control;
+      const badge = el.dataset.badge ? getElById(el.dataset.badge) : null;
+      let lastSentAt = 0;
+      let lastSentValue = null;
+      let timer = null;
+
+      function send() {
+        if (timer) { clearTimeout(timer); timer = null; }
+        if (el.value === lastSentValue) return; // nothing new to apply
+        lastSentValue = el.value;
+        lastSentAt = Date.now();
+        fetch('/?' + param + '=' + encodeURIComponent(el.value)
+          + '&ts=' + nextControlTs()).catch(() => {});
+      }
+
+      function schedule() {
+        const wait = CONTROL_THROTTLE_MS - (Date.now() - lastSentAt);
+        if (wait <= 0) {
+          send();
+        } else if (!timer) {
+          timer = setTimeout(send, wait);
+        }
+      }
+
+      el.addEventListener('input', () => {
+        if (badge) badge.innerText = formatControlValue(el);
+        if (el.dataset.setview) setView(el.dataset.setview);
+        schedule();
+      });
+      el.addEventListener('change', send); // final value on release
+
+      if (badge) badge.innerText = formatControlValue(el);
+    }
+
+    document.querySelectorAll('input[type="range"][data-control]').forEach(bindControl);
 
     function startMjpegStream() {
       if (!streamCanvas)

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
@@ -260,7 +260,7 @@ class StreamingService : LifecycleService() {
                     if (!encoders.any { it.hasClients() })
                         launchMain { stopCamera(); onClientDisconnected?.invoke() }
                 },
-                onControlCommand = { key, value -> handleRemoteControl(key, value) },
+                onControlCommand = { key, value, ts -> handleRemoteControl(key, value, ts) },
                 onSnapshot = { id -> snapshot(id) }
             )
             // Initialize encoders with the streaming server helper
@@ -579,7 +579,21 @@ class StreamingService : LifecycleService() {
      *   torch=on|off|toggle   focus=1   exposure=<ev>   zoom=<ratio>
      *   camera=<id>|front|back|toggle   resolution=WxH   api=auto|camerax|camera1
      */
-    private fun handleRemoteControl(key: String, value: String) {
+    /** Last accepted client timestamp per control key. */
+    private val controlTimestamps = HashMap<String, Long>()
+
+    /** True unless [ts] is older-or-equal to the last one accepted for [key] (0 = no ordering info). */
+    private fun acceptControl(key: String, ts: Long): Boolean {
+        if (ts == 0L) return true
+        if (ts <= (controlTimestamps[key] ?: 0L)) return false
+        controlTimestamps[key] = ts
+        return true
+    }
+
+    // Synchronized so the timestamp check and the (async) dispatch stay ordered per request.
+    @Synchronized
+    private fun handleRemoteControl(key: String, value: String, ts: Long = 0L) {
+        if (!acceptControl(key, ts)) return
         val prefs = PreferenceManager.getDefaultSharedPreferences(this)
         val id = camId()
         when (key) {

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/StreamingServerHelper.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/StreamingServerHelper.kt
@@ -54,7 +54,7 @@ class StreamingServerHelper(
     private val onLog: (String) -> Unit = {},
     private val onClientConnected: () -> Unit = {},
     private val onClientDisconnected: () -> Unit = {},
-    private val onControlCommand: (String, String) -> Unit = { _, _ -> },
+    private val onControlCommand: (String, String, Long) -> Unit = { _, _, _ -> },
     private val onSnapshot: (String) -> ByteArray? = { null }
 ) {
     data class Client(
@@ -624,8 +624,12 @@ class StreamingServerHelper(
             }
 
             if (uri.contains("?")) {
-                parseQueryParams(uri).forEach { (key, value) ->
-                    onControlCommand(key, value)
+                val params = parseQueryParams(uri)
+                val ts = params["ts"]?.toLongOrNull() ?: 0L // for ordering; 0 = none
+
+                params.forEach { (key, value) ->
+                    if (key == "ts") return@forEach
+                    onControlCommand(key, value, ts)
                 }
                 writer.print("HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nConnection: close\r\n\r\nOK")
                 writer.flush()


### PR DESCRIPTION
## What this does

Two related improvements to the web control panel.

### 1. Sliders now apply the released value reliably (with live preview kept)
Previously every range slider (zoom, scale, exposure, contrast, audio gain) fired a `fetch` on **every** `input` event while dragging. A single touch drag emits dozens of events, so the browser fired many concurrent requests that the server could apply out of order — the value that "stuck" was often a stale mid-drag one instead of where the slider was released, and the far-left end sometimes appeared to do nothing.

- **Client (`index.html`):** the live preview is kept (the value is still sent while dragging so you see the change immediately), but sends are throttled (~100 ms) so a drag produces a handful of requests instead of dozens, plus a guaranteed final send on `change` (release). Every request carries a monotonically increasing `ts` timestamp (wall-clock based, so it stays monotonic across page reloads). Because the server now orders by timestamp, the client also **de-duplicates on value** — it skips a send when the value is unchanged, dropping the no-op `change` after a throttle tick and any wiggle back to a value already sent. Sliders are bound declaratively via `data-control` / `data-badge` attributes instead of repeated inline `oninput` handlers.
- **Server (`StreamingService.kt`, `StreamingServerHelper.kt`):** parses the `ts` param and records the last accepted timestamp per control, ignoring any request older-or-equal to it. `handleRemoteControl` is `@Synchronized` so the timestamp check and the dispatch of the side-effect are atomic per request — an accepted newer request is always dispatched before an older one (main-thread posts run FIFO), so the released value wins even under genuinely concurrent connections. A missing/zero timestamp keeps the old "always apply" behaviour for other clients.

### 2. Controls grouped into "Camera Control" vs "Post Processing"
It wasn't obvious which sliders drive the real camera hardware and which are digital effects on the stream. They're now grouped with short hints:
- **Camera Control** — Resolution, Zoom, Exposure. These change the sensor/lens (e.g. optical zoom where the device supports it), not the image afterwards.
- **Post Processing** — Scale, Contrast, Frame Delay. Applied to the stream after capture (digital; `scale`/`contrast` are handled in `MjpegStreamingEncoder`).

## Files
- `app/src/main/assets/index.html` — throttled + de-duplicated sender with timestamp, declarative binding, grouped UI + hints
- `.../StreamingService.kt` — per-control timestamp guard, synchronized apply
- `.../helpers/StreamingServerHelper.kt` — parse `ts` and pass it to the control handler

## Testing
Built with `assembleDebug` and installed on a physical device (POCO F7 Pro, Android 16): the preview updates live while dragging, and releasing anywhere (including the far-left end) reliably applies the released value even with fast back-and-forth dragging. The grouped labels render as expected.

---
*Implemented by Claude (Claude Code). Verified on a real device by a human.*