### PR TITLE
Add local MP4 recording support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,10 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation" />
 
     <uses-feature android:name="android.hardware.camera.any" />

--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -353,6 +353,13 @@
           </select>
           <button id="snapBtn" class="btn btn-action" onclick="window.open('/video/snapshot','_blank')">📸 Take
             Snapshot</button>
+
+          <p class="group-title">Local Recording</p>
+          <div style="display:flex; gap:8px; margin-bottom:8px;">
+            <button id="recordStartBtn" class="btn btn-action" style="flex:1; background:#d32f2f; border-color:#b71c1c; margin-bottom:0;" onclick="toggleRecording(true)">🔴 Record</button>
+            <button id="recordStopBtn" class="btn btn-action" style="flex:1; background:#333; border-color:#555; margin-bottom:0;" onclick="toggleRecording(false)">⏹️ Stop</button>
+          </div>
+          <div id="recordStatusBadge" style="font-size:12px; color:#aaa; text-align:center; margin-bottom:12px;">Status: Stopped</div>
         </div>
 
         <p class="notice">Some changes will momentarily restart the camera.</p>
@@ -1406,6 +1413,51 @@
           }
         });
     }
+
+    let isRecording = false;
+    function updateRecordingUi(statusData) {
+      const startBtn = getElById('recordStartBtn');
+      const stopBtn = getElById('recordStopBtn');
+      const statusBadge = getElById('recordStatusBadge');
+      if (!statusBadge) return;
+      isRecording = !!(statusData && statusData.recording);
+      if (isRecording) {
+        const secs = Math.floor((statusData.durationMs || 0) / 1000);
+        const mins = Math.floor(secs / 60);
+        const remSecs = secs % 60;
+        const timeStr = `${mins}:${remSecs < 10 ? '0' : ''}${remSecs}`;
+        statusBadge.innerHTML = `<span style="color:#ff5252;font-weight:bold;">🔴 Recording (${timeStr})</span>`;
+        if (startBtn) startBtn.style.opacity = '0.5';
+        if (stopBtn) stopBtn.style.background = '#d32f2f';
+      } else {
+        statusBadge.innerHTML = '<span style="color:#aaa;">Status: Stopped</span>';
+        if (startBtn) startBtn.style.opacity = '1';
+        if (stopBtn) stopBtn.style.background = '#333';
+      }
+    }
+
+    function checkRecordingStatus() {
+      fetch('/record/status')
+        .then(r => r.json())
+        .then(data => updateRecordingUi(data))
+        .catch(() => {});
+    }
+
+    function toggleRecording(start) {
+      const url = start ? '/record/start' : '/record/stop';
+      fetch(url, { method: 'POST' })
+        .then(r => r.json())
+        .then(data => {
+          if (data.error) {
+            alert('Recording Message: ' + (data.message || data.error));
+          }
+          checkRecordingStatus();
+        })
+        .catch(err => alert('Failed to send recording command: ' + err));
+    }
+
+    setInterval(checkRecordingStatus, 3000);
+    checkRecordingStatus();
   </script>
 </body>
 

--- a/app/src/main/assets/index.html
+++ b/app/src/main/assets/index.html
@@ -351,15 +351,10 @@
             <option value="stream">Match stream (fast)</option>
             <option value="max">Max (full sensor)</option>
           </select>
-          <button id="snapBtn" class="btn btn-action" onclick="window.open('/video/snapshot','_blank')">📸 Take
-            Snapshot</button>
-
-          <p class="group-title">Local Recording</p>
           <div style="display:flex; gap:8px; margin-bottom:8px;">
-            <button id="recordStartBtn" class="btn btn-action" style="flex:1; background:#d32f2f; border-color:#b71c1c; margin-bottom:0;" onclick="toggleRecording(true)">🔴 Record</button>
-            <button id="recordStopBtn" class="btn btn-action" style="flex:1; background:#333; border-color:#555; margin-bottom:0;" onclick="toggleRecording(false)">⏹️ Stop</button>
+            <button id="recordToggleBtn" class="btn btn-action" style="flex:1; min-width:0; margin-bottom:0;" onclick="toggleRecording()">🔴 Record</button>
+            <button id="snapBtn" class="btn btn-action" style="flex:1; min-width:0; margin-bottom:0;" onclick="window.open('/video/snapshot','_blank')">📸 Take Snapshot</button>
           </div>
-          <div id="recordStatusBadge" style="font-size:12px; color:#aaa; text-align:center; margin-bottom:12px;">Status: Stopped</div>
         </div>
 
         <p class="notice">Some changes will momentarily restart the camera.</p>
@@ -885,6 +880,9 @@
       const mj = getElById('modeMjpegBtn'), h = getElById('modeH264Btn');
       if (mj) mj.className = 'btn' + (mode === 'mjpeg' ? ' active' : '');
       if (h && !h.disabled) h.className = 'btn' + (mode === 'h264' ? ' active' : '');
+
+      const recordToggleBtn = getElById('recordToggleBtn');
+      if (recordToggleBtn) recordToggleBtn.style.display = (mode === 'h264') ? 'block' : 'none';
 
       if (avDelay && avDelayVal) {
         const currentVal = avDelay.value;
@@ -1416,23 +1414,24 @@
 
     let isRecording = false;
     function updateRecordingUi(statusData) {
-      const startBtn = getElById('recordStartBtn');
-      const stopBtn = getElById('recordStopBtn');
-      const statusBadge = getElById('recordStatusBadge');
-      if (!statusBadge) return;
+      const toggleBtn = getElById('recordToggleBtn');
       isRecording = !!(statusData && statusData.recording);
       if (isRecording) {
         const secs = Math.floor((statusData.durationMs || 0) / 1000);
         const mins = Math.floor(secs / 60);
         const remSecs = secs % 60;
         const timeStr = `${mins}:${remSecs < 10 ? '0' : ''}${remSecs}`;
-        statusBadge.innerHTML = `<span style="color:#ff5252;font-weight:bold;">🔴 Recording (${timeStr})</span>`;
-        if (startBtn) startBtn.style.opacity = '0.5';
-        if (stopBtn) stopBtn.style.background = '#d32f2f';
+        if (toggleBtn) {
+          toggleBtn.textContent = `⏹️ ${timeStr}`;
+          toggleBtn.style.background = '#d32f2f';
+          toggleBtn.style.borderColor = '#b71c1c';
+        }
       } else {
-        statusBadge.innerHTML = '<span style="color:#aaa;">Status: Stopped</span>';
-        if (startBtn) startBtn.style.opacity = '1';
-        if (stopBtn) stopBtn.style.background = '#333';
+        if (toggleBtn) {
+          toggleBtn.textContent = '🔴 Record';
+          toggleBtn.style.background = '';
+          toggleBtn.style.borderColor = '';
+        }
       }
     }
 
@@ -1443,8 +1442,8 @@
         .catch(() => {});
     }
 
-    function toggleRecording(start) {
-      const url = start ? '/record/start' : '/record/stop';
+    function toggleRecording() {
+      const url = isRecording ? '/record/stop' : '/record/start';
       fetch(url, { method: 'POST' })
         .then(r => r.json())
         .then(data => {

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
@@ -43,6 +43,9 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+/** (success, httpStatusLine, jsonBody) */
+private typealias RecordingResponse = Triple<Boolean, String, String>
+
 /**
  * Two backends behind CaptureBackend, auto-picked by hardware level (override via api pref):
  *   CameraX (global default) — ImageAnalysis YUV -> encoder + ImageCapture full-res stills.
@@ -66,6 +69,7 @@ class StreamingService : LifecycleService() {
     @Volatile private var cameraXGlPipe: CameraGlPipe? = null   // CameraX H.264 GL pipe
     @Volatile private var backend: CaptureBackend? = null   // CameraXCapture (default) or Camera1Capture (legacy)
     @Volatile private var captureRunning = false
+    @Volatile private var localRecorder: LocalRecorder? = null
 
     @Volatile private var frontFacing = false             // false = back camera (read across threads)
     @Volatile private var selectedCameraId: String? = null
@@ -173,6 +177,7 @@ class StreamingService : LifecycleService() {
         super.onDestroy()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P)
             try { unregisterReceiver(notificationChannelReceiver) } catch (_: Exception) {}
+        safeStopRecording()
         stopCamera()
         lifecycleScope.launch(Dispatchers.IO) { streamingServerHelper?.stopStreamingServer() }
     }
@@ -214,7 +219,7 @@ class StreamingService : LifecycleService() {
         }
     }
     fun isCameraRunning() = captureRunning
-    fun hasActiveClients() = encoders.any { it.hasClients() }
+    fun hasActiveClients() = encoders.any { it.hasClients() } || localRecorder?.isRecording == true
     fun switchCamera() {
         selectCamera(!frontFacing, null)
         PreferenceManager.getDefaultSharedPreferences(this).edit()
@@ -281,7 +286,7 @@ class StreamingService : LifecycleService() {
                 onClientDisconnected = {
                     launchMain {
                         onClientDisconnected?.invoke()
-                        if (!encoders.any { it.hasClients() }) {
+                        if (hasActiveClients()) {
                             if (currentSurfaceProvider != null) {
                                 debouncedStartCamera()
                             } else {
@@ -293,7 +298,10 @@ class StreamingService : LifecycleService() {
                     }
                 },
                 onControlCommand = { key, value, ts -> handleRemoteControl(key, value, ts) },
-                onSnapshot = { id -> snapshot(id) }
+                onSnapshot = { id -> snapshot(id) },
+                onRecordStart = { startRecording() },
+                onRecordStop = { stopRecording() },
+                onRecordStatus = { getRecordingStatus() }
             )
             // Initialize encoders with the streaming server helper
             h264StreamingEncoder = H264StreamingEncoder(this, streamingServerHelper!!) { Log.i(TAG, "H264: $it"); onLog?.invoke(it) }
@@ -517,7 +525,7 @@ class StreamingService : LifecycleService() {
                 val h264 = h264StreamingEncoder
                 var h264SurfaceProvider: Preview.SurfaceProvider? = null
 
-                if (h264 != null && h264.hasClients() && supportsSurfaceEncoder()) {
+                if (h264 != null && (h264.hasClients() || localRecorder?.isRecording == true) && supportsSurfaceEncoder()) {
                     val prefs = PreferenceManager.getDefaultSharedPreferences(this)
                     val fps = prefs.getString("stream_fps", "30")?.toIntOrNull() ?: 30
                     val fpsCoerced = fps.coerceIn(1, 60)
@@ -571,9 +579,14 @@ class StreamingService : LifecycleService() {
                         cameraXGlPipe?.let { pipe ->
                             pipe.frameWidth = img.width; pipe.frameHeight = img.height
                         }
+                        val recording = localRecorder?.isRecording == true
                         val activeEncoders = encoders.filter { it.hasClients() }
-                        if (activeEncoders.isEmpty()) return@CameraXCapture
-                        activeEncoders.forEach { it.processFrame(img) }
+                        if (recording && h264StreamingEncoder != null) {
+                            h264StreamingEncoder?.processFrame(img)
+                            activeEncoders.filter { it != h264StreamingEncoder }.forEach { it.processFrame(img) }
+                        } else if (activeEncoders.isNotEmpty()) {
+                            activeEncoders.forEach { it.processFrame(img) }
+                        }
                     } catch (e: OutOfMemoryError) {
                         Log.e(TAG, "ImageAnalysis OOM — dropping frame: ${e.message}")
                         DeviceMemoryHelper.updateMemoryPressure(android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL)
@@ -616,6 +629,7 @@ class StreamingService : LifecycleService() {
     }
 
     private fun stopCamera() {
+        safeStopRecording()
         cameraCloseStartTime = System.currentTimeMillis()
         backend?.stop(); backend = null
         val closeDuration = System.currentTimeMillis() - cameraCloseStartTime
@@ -957,6 +971,99 @@ class StreamingService : LifecycleService() {
         }
     }
 
+
+    // ---------------- local recording ----------------
+
+    fun startRecording(): RecordingResponse {
+        if (localRecorder?.isRecording == true) return Triple(false, "409 Conflict",
+            """{"error":"already_recording","message":"Recording is already in progress","uri":"${localRecorder?.recordingLocation() ?: ""}"}"""
+        )
+
+        // Ensure camera and H.264 encoder are started on demand
+        if (!captureRunning || !hasActiveClients()) {
+            val latch = CountDownLatch(1)
+            launchMain {
+                startCamera(force = true)
+                latch.countDown()
+            }
+            try { latch.await(3, TimeUnit.SECONDS) } catch (_: Exception) {}
+        }
+
+        var enc = h264StreamingEncoder?.h264HardwareEncoder
+        var attempts = 0
+        while (enc == null && attempts < 20) {
+            try { Thread.sleep(100) } catch (_: Exception) {}
+            enc = h264StreamingEncoder?.h264HardwareEncoder
+            attempts++
+        }
+
+        if (enc == null) {
+            return Triple(false, "503 Service Unavailable",
+                """{"error":"no_encoder","message":"Failed to initialize H.264 encoder"}"""
+            )
+        }
+
+        return try {
+            val recorder = LocalRecorder(this, enc.width, enc.height)
+            recorder.start()
+            enc.onRecordFrame = { bytes, isKey, pts -> recorder.feedFrame(bytes, isKey, pts) }
+            enc.requestKeyFrame()
+            localRecorder = recorder
+            Triple(true, "201 Created", recorder.statusJson())
+        } catch (e: Exception) {
+            Log.e(TAG, "startRecording failed", e)
+            Triple(false, "500 Internal Server Error",
+                """{"error":"start_failed","message":"${e.message?.replace("\"", "'") ?: "unknown error"}"}"""
+            )
+        }
+    }
+
+    fun stopRecording(): RecordingResponse {
+        val recorder = localRecorder ?: return Triple(false, "409 Conflict",
+            """{"error":"not_recording","message":"No recording is in progress"}"""
+        )
+        return try {
+            h264StreamingEncoder?.h264HardwareEncoder?.onRecordFrame = null
+            val finalStatus = recorder.statusJson()
+            recorder.stop()
+            localRecorder = null
+
+            // If no remote network streaming clients are connected, update camera state
+            if (!encoders.any { it.hasClients() }) {
+                launchMain {
+                    if (currentSurfaceProvider != null) {
+                        debouncedStartCamera()
+                    } else {
+                        stopCamera()
+                    }
+                }
+            }
+            Triple(true, "200 OK", finalStatus)
+        } catch (e: Exception) {
+            Log.e(TAG, "stopRecording failed", e)
+            localRecorder = null
+            Triple(false, "500 Internal Server Error",
+                """{"error":"stop_failed","message":"${e.message?.replace("\"", "'") ?: "unknown error"}"}"""
+            )
+        }
+    }
+
+    fun getRecordingStatus(): String {
+        return localRecorder?.statusJson()
+            ?: """{"recording":false}"""
+    }
+
+    /** Safely stops any active recording (used in stopCamera/onDestroy safety nets). */
+    private fun safeStopRecording() {
+        try {
+            h264StreamingEncoder?.h264HardwareEncoder?.onRecordFrame = null
+            localRecorder?.stop()
+        } catch (e: Exception) {
+            Log.e(TAG, "safeStopRecording: ${e.message}")
+        } finally {
+            localRecorder = null
+        }
+    }
 
     private fun generateRandomPassword(): String {
         val r = SecureRandom()

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/H264HardwareEncoder.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/H264HardwareEncoder.kt
@@ -42,6 +42,9 @@ class H264HardwareEncoder(
     private var partialFlags = 0
     private var frameCount = 0
 
+    /** Optional recording callback. Called with (annexBBytes, isKeyframe, presentationTimeUs). */
+    @Volatile var onRecordFrame: ((ByteArray, Boolean, Long) -> Unit)? = null
+
     @Volatile var hasSurfaceBeenProvided = false
     @Volatile private var isStopped = false
     @Volatile private var isReleasedByCameraX = false
@@ -339,6 +342,7 @@ class H264HardwareEncoder(
 
     private fun drainLoop() {
         val info = MediaCodec.BufferInfo()
+        var partialPtsUs = 0L
         try {
             while (running) {
                 val idx = synchronized(codecLock) { codec.dequeueOutputBuffer(info, 10000) }
@@ -355,6 +359,7 @@ class H264HardwareEncoder(
                             val data = ByteArray(info.size)
                             buf.get(data)
 
+                            if (partialFlags == 0) partialPtsUs = info.presentationTimeUs
                             partialFlags = partialFlags or info.flags
                             val isPartial = (info.flags and MediaCodec.BUFFER_FLAG_PARTIAL_FRAME) != 0
                             val accessUnit = accessUnitAssembler.append(data, isPartial)
@@ -372,6 +377,7 @@ class H264HardwareEncoder(
                     }
                     // Never retain a MediaCodec output buffer while network work is scheduled.
                     prepared?.let {
+                        onRecordFrame?.invoke(it.bytes, it.isKeyframe, partialPtsUs)
                         onNal(it.bytes, it.isKeyframe)
                     }
                 }

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/LocalRecorder.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/LocalRecorder.kt
@@ -1,0 +1,355 @@
+package com.github.digitallyrefined.androidipcamera.helpers
+
+import android.content.ContentValues
+import android.content.Context
+import android.media.MediaCodec
+import android.media.MediaFormat
+import android.media.MediaMuxer
+import android.media.MediaScannerConnection
+import android.net.Uri
+import android.os.Build
+import android.os.Environment
+import android.os.ParcelFileDescriptor
+import android.provider.MediaStore
+import android.util.Log
+import org.json.JSONObject
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.ByteBuffer
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+/**
+ * Records H.264 access units from the streaming encoder into a local MP4 file.
+ *
+ * Thread safety: [feedFrame] runs on the encoder drain thread; [stop] runs on the
+ * main/service thread. All muxer access is serialized via [muxerLock], and a volatile
+ * [released] flag provides a fast-path exit for [feedFrame] after [stop] completes.
+ *
+ * Storage: Uses MediaStore on API 29+ (scoped storage, no permissions needed) and
+ * legacy file I/O on API 24–28 (requires WRITE_EXTERNAL_STORAGE).
+ */
+class LocalRecorder(
+    private val context: Context,
+    val width: Int,
+    val height: Int
+) {
+    companion object {
+        private const val TAG = "LocalRecorder"
+        private const val SUBDIR = "AndroidIPCamera"
+    }
+
+    // --- Public state (read from any thread) ---
+    @Volatile var isRecording: Boolean = false
+        private set
+    @Volatile var recordingStartTimeMs: Long = 0L
+        private set
+
+    // --- Muxer state (guarded by muxerLock) ---
+    private val muxerLock = Any()
+    @Volatile private var released = false
+    private var muxer: MediaMuxer? = null
+    private var trackIndex = -1
+    private var muxerStarted = false
+
+    // --- Output references ---
+    private var mediaStoreUri: Uri? = null
+    private var outputFile: File? = null
+    private var pfd: ParcelFileDescriptor? = null
+
+    // --- Timestamp tracking ---
+    /** First presentation timestamp from the encoder, used to normalize PTS to start at 0. */
+    private var firstPtsUs = Long.MIN_VALUE
+    /** Last written presentation timestamp, enforcing strict monotonicity for MediaMuxer. */
+    private var lastPtsUs = -1L
+
+    /**
+     * Create the output file and MediaMuxer. The muxer track is NOT added here — it
+     * requires the first keyframe's SPS/PPS, which arrives in [feedFrame].
+     */
+    fun start() {
+        synchronized(muxerLock) {
+            check(!isRecording) { "Already recording" }
+            released = false
+            firstPtsUs = Long.MIN_VALUE
+            lastPtsUs = -1L
+            val filename = generateFilename()
+
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    // API 29+: MediaStore (scoped storage)
+                    val values = ContentValues().apply {
+                        put(MediaStore.Video.Media.DISPLAY_NAME, filename)
+                        put(MediaStore.Video.Media.MIME_TYPE, "video/mp4")
+                        put(MediaStore.Video.Media.RELATIVE_PATH, "${Environment.DIRECTORY_MOVIES}/$SUBDIR")
+                        put(MediaStore.Video.Media.IS_PENDING, 1)
+                    }
+                    val uri = context.contentResolver.insert(
+                        MediaStore.Video.Media.EXTERNAL_CONTENT_URI, values
+                    ) ?: throw IllegalStateException("MediaStore insert failed")
+                    val fd = context.contentResolver.openFileDescriptor(uri, "rw")
+                        ?: throw IllegalStateException("Failed to open file descriptor for $uri")
+                    mediaStoreUri = uri
+                    pfd = fd
+                    muxer = MediaMuxer(fd.fileDescriptor, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+                } else {
+                    // API 24-28: Legacy file I/O
+                    @Suppress("DEPRECATION")
+                    val dir = File(
+                        Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES),
+                        SUBDIR
+                    )
+                    dir.mkdirs()
+                    val file = File(dir, filename)
+                    outputFile = file
+                    muxer = MediaMuxer(file.absolutePath, MediaMuxer.OutputFormat.MUXER_OUTPUT_MPEG_4)
+                }
+
+                isRecording = true
+                recordingStartTimeMs = System.currentTimeMillis()
+                Log.i(TAG, "Recording initialized: ${recordingLocation()}")
+            } catch (e: Exception) {
+                cleanupOutput()
+                throw e
+            }
+        }
+    }
+
+    /**
+     * Feed one H.264 access unit from the encoder drain loop.
+     *
+     * Called on the encoder thread at frame rate (~30 fps). The first keyframe initializes
+     * the muxer track (SPS/PPS extraction). Non-keyframes before the first keyframe are dropped.
+     *
+     * @param annexB  Annex-B byte array (4-byte start codes) from H264ParameterSetCache
+     * @param isKeyframe  true if this access unit contains an IDR slice
+     * @param ptsUs  presentation timestamp in microseconds from MediaCodec.BufferInfo
+     */
+    fun feedFrame(annexB: ByteArray, isKeyframe: Boolean, ptsUs: Long) {
+        if (released) return                        // fast volatile check, no lock
+        synchronized(muxerLock) {
+            if (released) return                    // double-check after acquiring lock
+            if (!muxerStarted) {
+                if (!isKeyframe) return             // wait for the first keyframe
+                if (!initTrack(annexB)) return     // wait for a keyframe that contains SPS/PPS
+            }
+            writeFrame(annexB, isKeyframe, ptsUs)
+        }
+    }
+
+    /**
+     * Stop recording, finalize the MP4 file, and make it visible in Gallery/Files.
+     * Safe to call from any thread. Blocks until any in-flight [feedFrame] completes.
+     * If stopped before any keyframe was written, cleans up the empty file.
+     */
+    fun stop() {
+        var wasMuxerStarted = false
+        synchronized(muxerLock) {
+            released = true                         // blocks future feedFrame() calls
+            wasMuxerStarted = muxerStarted
+            if (muxerStarted) {
+                try { muxer?.stop() } catch (e: Exception) {
+                    Log.e(TAG, "muxer.stop(): ${e.message}")
+                }
+            }
+            try { muxer?.release() } catch (e: Exception) {
+                Log.e(TAG, "muxer.release(): ${e.message}")
+            }
+            muxer = null
+            muxerStarted = false
+            trackIndex = -1
+            isRecording = false
+        }
+
+        if (wasMuxerStarted) {
+            finalizeOutput()
+            Log.i(TAG, "Recording stopped & saved: ${recordingLocation()}")
+        } else {
+            cleanupOutput()
+            Log.w(TAG, "Recording stopped before any keyframe arrived; deleted empty output.")
+        }
+    }
+
+    /** Returns a display-friendly location (content:// URI on API 29+, file path on older). */
+    fun recordingLocation(): String = when {
+        mediaStoreUri != null -> mediaStoreUri.toString()
+        outputFile != null -> outputFile!!.absolutePath
+        else -> ""
+    }
+
+    /** JSON representation of the current recording status. */
+    fun statusJson(): String = JSONObject().apply {
+        val loc = recordingLocation()
+        put("recording", isRecording)
+        put("uri", loc)
+        put("durationMs", if (isRecording) System.currentTimeMillis() - recordingStartTimeMs else 0)
+        put("width", width)
+        put("height", height)
+    }.toString()
+
+    // ---- Private implementation ----
+
+    /**
+     * Extract SPS/PPS from the first keyframe, build a MediaFormat, and start the muxer.
+     * Must be called inside synchronized(muxerLock).
+     * Returns true if track was successfully initialized, false if SPS/PPS missing.
+     */
+    private fun initTrack(annexB: ByteArray): Boolean {
+        val ranges = H264Bitstream.nalRanges(annexB)
+        val spsRange = ranges.firstOrNull { it.type == 7 }
+        val ppsRange = ranges.firstOrNull { it.type == 8 }
+
+        if (spsRange == null || ppsRange == null) {
+            Log.w(TAG, "Keyframe missing SPS or PPS (SPS=${spsRange != null}, PPS=${ppsRange != null}); waiting for next keyframe")
+            return false
+        }
+
+        val format = MediaFormat.createVideoFormat(MediaFormat.MIMETYPE_VIDEO_AVC, width, height)
+
+        // csd-0 (SPS) and csd-1 (PPS) include their Annex-B start codes
+        val spsBytes = annexB.copyOfRange(spsRange.startCodeStart, spsRange.end)
+        format.setByteBuffer("csd-0", ByteBuffer.wrap(spsBytes))
+
+        val ppsBytes = annexB.copyOfRange(ppsRange.startCodeStart, ppsRange.end)
+        format.setByteBuffer("csd-1", ByteBuffer.wrap(ppsBytes))
+
+        val m = muxer ?: return false
+        trackIndex = m.addTrack(format)
+        m.start()
+        muxerStarted = true
+        Log.i(TAG, "Muxer track added: ${width}x${height}, SPS=${spsBytes.size}B, PPS=${ppsBytes.size}B")
+        return true
+    }
+
+    /**
+     * Convert one access unit from Annex-B to AVCC and write it to the muxer.
+     * Strips SPS/PPS/AUD NALs from the frame data (they belong only in csd-0/csd-1).
+     * Must be called inside synchronized(muxerLock).
+     */
+    private fun writeFrame(annexB: ByteArray, isKeyframe: Boolean, ptsUs: Long) {
+        val m = muxer ?: return
+        if (trackIndex < 0) return
+
+        // Normalize PTS so the MP4 starts at 0
+        if (firstPtsUs == Long.MIN_VALUE) firstPtsUs = ptsUs
+        var normalizedPts = maxOf(0L, ptsUs - firstPtsUs)
+
+        // Strict monotonicity check for MediaMuxer stability
+        if (normalizedPts <= lastPtsUs) {
+            normalizedPts = lastPtsUs + 1_000L // Bump by 1 ms
+        }
+        lastPtsUs = normalizedPts
+
+        // Strip non-VCL NALs (SPS/PPS/AUD) but keep Annex-B start codes intact.
+        // MediaMuxer handles Annex-B → AVCC conversion internally for MP4.
+        val stripped = stripNonVclNals(annexB)
+        if (stripped.isEmpty()) return
+
+        val buf = ByteBuffer.wrap(stripped)
+        val info = MediaCodec.BufferInfo().apply {
+            offset = 0
+            size = stripped.size
+            presentationTimeUs = normalizedPts
+            flags = if (isKeyframe) MediaCodec.BUFFER_FLAG_KEY_FRAME else 0
+        }
+
+        try {
+            m.writeSampleData(trackIndex, buf, info)
+        } catch (e: Exception) {
+            Log.e(TAG, "writeSampleData: ${e.message}")
+        }
+    }
+
+    /**
+     * Strip SPS (7), PPS (8), and AUD (9) NALs from Annex-B data, keeping start codes intact.
+     * Only VCL NALs (types 1–5) and SEI (type 6) are retained for sample data.
+     * SPS/PPS belong in the track's MediaFormat csd-0/csd-1, not in sample buffers.
+     * MediaMuxer handles the Annex-B → AVCC conversion internally when writing MP4.
+     */
+    private fun stripNonVclNals(annexB: ByteArray): ByteArray {
+        val ranges = H264Bitstream.nalRanges(annexB)
+        // Keep only VCL slices (1–5) and SEI (6)
+        val vclRanges = ranges.filter { it.type in 1..6 }
+        if (vclRanges.isEmpty()) return ByteArray(0)
+
+        // If all NALs are VCL, return the input as-is (common fast path)
+        if (vclRanges.size == ranges.size) return annexB
+
+        val out = ByteArrayOutputStream(annexB.size)
+        for (range in vclRanges) {
+            // Include the Annex-B start code + NAL data
+            out.write(annexB, range.startCodeStart, range.end - range.startCodeStart)
+        }
+        return out.toByteArray()
+    }
+
+    /** Make the completed MP4 visible in Gallery / file managers. */
+    private fun finalizeOutput() {
+        try {
+            pfd?.close()
+            pfd = null
+        } catch (e: Exception) {
+            Log.e(TAG, "close pfd: ${e.message}")
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // Clear IS_PENDING to make the file visible
+            mediaStoreUri?.let { uri ->
+                try {
+                    val values = ContentValues().apply {
+                        put(MediaStore.Video.Media.IS_PENDING, 0)
+                    }
+                    context.contentResolver.update(uri, values, null, null)
+                } catch (e: Exception) {
+                    Log.e(TAG, "finalize MediaStore: ${e.message}")
+                }
+            }
+        } else {
+            // Scan the file so it appears in Gallery
+            outputFile?.let { file ->
+                MediaScannerConnection.scanFile(
+                    context,
+                    arrayOf(file.absolutePath),
+                    arrayOf("video/mp4"),
+                    null
+                )
+            }
+        }
+    }
+
+    /** Clean up and delete incomplete or aborted files/URIs. */
+    private fun cleanupOutput() {
+        try {
+            pfd?.close()
+            pfd = null
+        } catch (e: Exception) {
+            Log.e(TAG, "close pfd in cleanup: ${e.message}")
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            mediaStoreUri?.let { uri ->
+                try {
+                    context.contentResolver.delete(uri, null, null)
+                } catch (e: Exception) {
+                    Log.e(TAG, "cleanup MediaStore: ${e.message}")
+                }
+            }
+        } else {
+            outputFile?.let { file ->
+                try {
+                    if (file.exists()) file.delete()
+                } catch (e: Exception) {
+                    Log.e(TAG, "cleanup legacy file: ${e.message}")
+                }
+            }
+        }
+        mediaStoreUri = null
+        outputFile = null
+    }
+
+    private fun generateFilename(): String {
+        val sdf = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
+        return "ipcam_${sdf.format(Date())}.mp4"
+    }
+}

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/StreamingServerHelper.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/StreamingServerHelper.kt
@@ -60,7 +60,10 @@ class StreamingServerHelper(
     private val onClientConnected: () -> Unit = {},
     private val onClientDisconnected: () -> Unit = {},
     private val onControlCommand: (String, String, Long) -> Unit = { _, _, _ -> },
-    private val onSnapshot: (String) -> ByteArray? = { null }
+    private val onSnapshot: (String) -> ByteArray? = { null },
+    private val onRecordStart: () -> Triple<Boolean, String, String> = { Triple(false, "503 Service Unavailable", """{"error":"unavailable"}""") },
+    private val onRecordStop: () -> Triple<Boolean, String, String> = { Triple(false, "409 Conflict", """{"error":"not_recording"}""") },
+    private val onRecordStatus: () -> String = { """{"recording":false}""" }
 ) {
     data class Client(
         val socket: Socket,
@@ -679,6 +682,40 @@ class StreamingServerHelper(
                 } else {
                     writer.print("HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\nno frame"); writer.flush()
                 }
+                try { socket.close() } catch (_: Exception) {}
+                return
+            }
+
+            // ---- Recording endpoints ----
+            if (path == "/record/start" && requestParts[0] == "POST") {
+                val (_, status, json) = onRecordStart()
+                writer.print("HTTP/1.1 $status\r\n")
+                writer.print("Content-Type: application/json\r\n")
+                writer.print("Connection: close\r\n\r\n")
+                writer.print(json)
+                writer.flush()
+                try { socket.close() } catch (_: Exception) {}
+                return
+            }
+
+            if (path == "/record/stop" && requestParts[0] == "POST") {
+                val (_, status, json) = onRecordStop()
+                writer.print("HTTP/1.1 $status\r\n")
+                writer.print("Content-Type: application/json\r\n")
+                writer.print("Connection: close\r\n\r\n")
+                writer.print(json)
+                writer.flush()
+                try { socket.close() } catch (_: Exception) {}
+                return
+            }
+
+            if (path == "/record/status") {
+                val json = onRecordStatus()
+                writer.print("HTTP/1.1 200 OK\r\n")
+                writer.print("Content-Type: application/json\r\n")
+                writer.print("Connection: close\r\n\r\n")
+                writer.print(json)
+                writer.flush()
                 try { socket.close() } catch (_: Exception) {}
                 return
             }


### PR DESCRIPTION
feat: add local MP4 recording from H.264 streaming encoder

Record video directly to the phone's Gallery (Movies/AndroidIPCamera/) by tapping into the existing H264HardwareEncoder pipeline — no second encoder, no extra camera surface, no CameraX VideoCapture.

Recording pipeline:
  Camera → H264HardwareEncoder → drainLoop() → onRecordFrame callback
  → LocalRecorder → MediaMuxer → MP4 file

New files:
- LocalRecorder.kt: MediaMuxer wrapper with SPS/PPS extraction, Annex-B NAL stripping, timestamp monotonicity enforcement, and scoped storage via MediaStore (API 29+) / legacy file IO (API 24-28). Cleans up incomplete files if stopped before first keyframe.

Modified files:
- H264HardwareEncoder.kt: Add onRecordFrame callback with correct partial-frame PTS propagation (partialPtsUs captured from first fragment in drainLoop).
- StreamingService.kt: Add startRecording/stopRecording/getRecordingStatus methods, on-demand camera+encoder init, IDR keyframe request on record start, hasActiveClients() includes recording state, and safeStopRecording() safety nets in stopCamera/onDestroy.
- StreamingServerHelper.kt: Wire REST endpoints POST /record/start, POST /record/stop, GET /record/status with JSON responses.
- AndroidManifest.xml: Add WRITE_EXTERNAL_STORAGE.
- index.html: Add Record/Stop buttons with status badge, duration counter, and 3-second polling via fetch API.