### PR TITLE
Add optional start on boot

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,8 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.NEARBY_WIFI_DEVICES" android:usesPermissionFlags="neverForLocation" />
+    <!-- Optional start on boot, off by default -->
+    <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
 
     <uses-feature android:name="android.hardware.camera.any" />
 
@@ -40,5 +42,15 @@
             android:name=".StreamingService"
             android:foregroundServiceType="camera|microphone"
             android:exported="false" />
+
+        <receiver
+            android:name=".BootReceiver"
+            android:enabled="true"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.BOOT_COMPLETED" />
+                <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/BootReceiver.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/BootReceiver.kt
@@ -1,0 +1,59 @@
+package com.github.digitallyrefined.androidipcamera
+
+import android.Manifest
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.util.Log
+import androidx.core.content.ContextCompat
+import androidx.preference.PreferenceManager
+
+/**
+ * Starts the streaming service after the device boots, when the "start_on_boot" preference is
+ * enabled. Useful for unattended installations where the device is expected to come back online by
+ * itself after a power cut or a reboot.
+ *
+ * StreamingService owns the camera and the HTTP server, so no activity needs to be shown.
+ */
+class BootReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != Intent.ACTION_BOOT_COMPLETED &&
+            intent.action != "android.intent.action.QUICKBOOT_POWERON"
+        ) {
+            return
+        }
+
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        if (!prefs.getBoolean("start_on_boot", false)) return
+
+        // The service is a camera foreground service; without the permission it cannot start.
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
+            != PackageManager.PERMISSION_GRANTED
+        ) {
+            Log.w(TAG, "start_on_boot is enabled but the camera permission is not granted")
+            return
+        }
+
+        // No activity is started on boot, and the activity is what normally calls
+        // startStreamingServer() once it binds — so ask the service to start the server itself.
+        val serviceIntent = Intent(context, StreamingService::class.java).apply {
+            action = StreamingService.ACTION_START_SERVER
+        }
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(serviceIntent)
+            } else {
+                context.startService(serviceIntent)
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to start streaming service on boot", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "BootReceiver"
+    }
+}

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
@@ -104,6 +104,7 @@ class StreamingService : LifecycleService() {
         const val ACTION_STOP_SERVICE = "com.github.digitallyrefined.androidipcamera.STOP_SERVICE"
         const val ACTION_RESTART_NOTIFICATION = "com.github.digitallyrefined.androidipcamera.RESTART_NOTIFICATION"
         const val ACTION_RESTART_SERVER = "com.github.digitallyrefined.androidipcamera.RESTART_SERVER"
+        const val ACTION_START_SERVER = "com.github.digitallyrefined.androidipcamera.START_SERVER"
     }
 
     inner class LocalBinder : Binder() { fun getService(): StreamingService = this@StreamingService }
@@ -115,6 +116,9 @@ class StreamingService : LifecycleService() {
             ACTION_STOP_SERVICE -> { handleStopService(); return START_NOT_STICKY }
             ACTION_RESTART_NOTIFICATION -> startForegroundService()
             ACTION_RESTART_SERVER -> restartServer()
+            // Cold start with no activity bound (e.g. from BootReceiver): the activity normally
+            // calls startStreamingServer() after binding, so start it here instead.
+            ACTION_START_SERVER -> startStreamingServer()
         }
         return super.onStartCommand(intent, flags, startId)
     }

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,6 +2,14 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory
+        android:title="Startup">
+        <CheckBoxPreference
+            android:key="start_on_boot"
+            android:title="Start on boot"
+            android:summary="Start the camera server automatically after the device restarts"
+            android:defaultValue="false" />
+    </PreferenceCategory>
+    <PreferenceCategory
         android:title="Authentication">
         <CheckBoxPreference
             android:key="enable_auth"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -2,14 +2,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <PreferenceCategory
-        android:title="Startup">
-        <CheckBoxPreference
-            android:key="start_on_boot"
-            android:title="Start on boot"
-            android:summary="Start the camera server automatically after the device restarts"
-            android:defaultValue="false" />
-    </PreferenceCategory>
-    <PreferenceCategory
         android:title="Authentication">
         <CheckBoxPreference
             android:key="enable_auth"
@@ -51,5 +43,14 @@
             android:title="Test Certificate Setup"
             android:summary="Validate your certificate configuration"
             android:persistent="false" />
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:title="Startup">
+        <CheckBoxPreference
+            android:key="start_on_boot"
+            android:title="Start on boot"
+            android:summary="Start the camera server automatically after the device restarts"
+            android:defaultValue="false" />
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Closes #46

## What

Adds an optional **"Start on boot"** preference (a new "Startup" category, **off by default**) that starts the camera server automatically after the device restarts.

## Why

For a fixed, unattended install — a camera on a wall or in a window — the device needs to come back on its own after a reboot or a power cut. Today the server only starts when someone opens the app, so any restart silently takes the camera offline until a person notices and taps the icon.

## How

`BootReceiver` handles `BOOT_COMPLETED` and starts `StreamingService`, which owns both the camera and the HTTP server, so no activity has to be shown.

The receiver sends a new `ACTION_START_SERVER` rather than a bare start intent. That part is not obvious, and I got it wrong on the first attempt: starting the service alone is **not** enough, because `startStreamingServer()` is normally called by `MainActivity` after it binds (`MainActivity.kt:66`). With no activity on boot, the service came up correctly as a foreground service with the camera open and a notification posted — but nothing ever listened on 4444. The existing `ACTION_RESTART_SERVER` cannot be reused for this either, since `restartServer()` dereferences `streamingServerHelper`, which is still `null` on a cold start.

Guards:
- returns early if `start_on_boot` is off, so nothing changes for existing users
- skips starting the service (with a log line) when `CAMERA` is not granted, instead of letting the foreground service fail

I did not add `LOCKED_BOOT_COMPLETED`, since it is only delivered to direct-boot-aware components and this receiver is not one.

## Testing

Built and **verified on real hardware**, not just compiled: a Cyrus CM17XA_EEA (Android 10, API 29, `armeabi-v7a`, single rear lens), running the app alongside a dashboard app.

- With the preference **off**: no boot behaviour change.
- With it **on**: across repeated reboots the app is started by `BootReceiver` and the server binds by itself.

```
ActivityManager: Start proc 6044:com.github.digitallyrefined.androidipcamera
                 for broadcast {…/.BootReceiver}

$ adb shell ss -ltn | grep 4444
LISTEN  0  0  *:4444  *:*
```

`/video/mjpeg` was then consumed by Home Assistant's `mjpeg` integration after a cold boot with no interaction at all.

Two timing notes from testing, in case they help anyone reproducing it: on this fairly slow device the app appears roughly 4–5 minutes into boot (dex2oat verification), and the server takes ~10 s after launch to bind — so checking too early looks like a failure when it is not.

Happy to adjust naming, the preference wording, or the placement of the new category if you would prefer something different.
