### PR TITLE
Restart the streaming server after a START_STICKY restart

### DIFF
--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/StreamingService.kt
@@ -139,6 +139,12 @@ class StreamingService : LifecycleService() {
             // calls startStreamingServer() after binding, so start it here instead.
             ACTION_START_SERVER -> startStreamingServer()
         }
+        // A null intent means the system re-created this START_STICKY service after killing the
+        // process. Nothing starts the server in that path — no activity binds, and onCreate() only
+        // posts the notification — so the service comes back looking healthy (foreground
+        // notification, camera available) with nothing listening on the port. startStreamingServer()
+        // early-returns when the socket is already open, so this is safe to reach on any path.
+        if (intent == null) startStreamingServer()
         return super.onStartCommand(intent, flags, startId)
     }
 

--- a/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/StreamingServerHelper.kt
+++ b/app/src/main/kotlin/com/github/digitallyrefined/androidipcamera/helpers/StreamingServerHelper.kt
@@ -111,6 +111,8 @@ class StreamingServerHelper(
     /** Disconnect streaming clients whose writes have not completed within this window. */
     private val STALE_WRITE_TIMEOUT_MS = 15_000L
     private val CONNECTION_CLEANUP_INTERVAL_MS = 60_000L
+    /** Wait before restarting a server whose accept loop ended on its own — see scheduleServerRestart. */
+    private val SERVER_RESTART_DELAY_MS = 5_000L
     /** Hard cap on the whole /video/snapshot request (snapshot() is already internally bounded). */
     private val SNAPSHOT_TOTAL_WAIT_MS = 14_000L
     private val SNAPSHOT_MAX_ATTEMPTS = 3
@@ -146,6 +148,29 @@ class StreamingServerHelper(
         } catch (_: Exception) {
             value
         }
+
+    /**
+     * Brings the server back after the accept loop ended without anyone asking it to.
+     *
+     * The failure this exists for is silent: the service keeps running with its foreground
+     * notification and the camera still available, but the port is dead, so nothing on the device
+     * looks wrong and the outage is only visible to whoever tries to connect. There is no other
+     * recovery path — the activity only starts the server when it binds, so an app left running in
+     * the background stays dead until it is force-stopped and relaunched by hand.
+     *
+     * A single delayed attempt is enough to keep retrying: if the restart also fails, its own
+     * accept loop ends the same way and schedules the next one, so this backs off at a fixed
+     * interval for as long as the failure lasts.
+     */
+    private fun scheduleServerRestart(generation: Long) {
+        CoroutineScope(Dispatchers.IO).launch {
+            kotlinx.coroutines.delay(SERVER_RESTART_DELAY_MS)
+            val stillStopped = synchronized(this@StreamingServerHelper) { generation == serverGeneration }
+            if (!stillStopped) return@launch  // something already restarted it
+            onLog("Server ended unexpectedly, restarting")
+            startStreamingServer()
+        }
+    }
 
     fun stopServer() {
         synchronized(this) {
@@ -253,6 +278,9 @@ class StreamingServerHelper(
         synchronized(this) {
               serverJob = CoroutineScope(Dispatchers.IO).launch {
               var localServerSocket: ServerSocket? = null
+              // Only set once the socket is live and published, so a server that never managed to
+              // bind (bad certificate, port in use) is not retried forever by the supervisor below.
+              var serverWasPublished = false
               try {
                   val prefs = PreferenceManager.getDefaultSharedPreferences(context)
                   val secureStorage = SecureStorage(context)
@@ -431,6 +459,7 @@ class StreamingServerHelper(
                   }
                   if (!published) return@launch
 
+                  serverWasPublished = true
                   onLog("Server started on port $streamPort (${if (useTLS) "HTTPS" else "HTTP"})")
                   // Clear the starting flag now that server is running
                   synchronized(this@StreamingServerHelper) {
@@ -477,10 +506,15 @@ class StreamingServerHelper(
                   onLog("Could not start server: ${e.message}")
               } finally {
                   try { localServerSocket?.close() } catch (_: IOException) {}
-                  synchronized(this@StreamingServerHelper) {
+                  val endedOnItsOwn = synchronized(this@StreamingServerHelper) {
                       if (serverSocket === localServerSocket) serverSocket = null
                       if (generation == serverGeneration) isStarting = false
+                      // stopServer() and every new start bump serverGeneration. If it is still
+                      // ours, nobody asked this loop to end — the socket was closed underneath it
+                      // or an exception escaped — and nothing else will bring the server back.
+                      generation == serverGeneration
                   }
+                  if (serverWasPublished && endedOnItsOwn) scheduleServerRestart(generation)
               }
             }
         }


### PR DESCRIPTION
On a low-memory device Android kills the app regularly and re-creates the foreground service, delivering a **null `Intent`**. That matches no branch in `onStartCommand`, and nothing else starts the HTTP server — `MainActivity` is what normally calls `startStreamingServer()` once it binds, and there is no activity on that path.

The result is a service that looks completely healthy — foreground notification posted, camera available — with a closed port. Only a client discovers otherwise. Force-stopping and relaunching recovers it; a plain relaunch does not.

Observed on a 2 GB Android 10 device roughly every 45–90 minutes, which made an MJPEG camera unusable for days at a time before the cause was found:

```
Process ...androidipcamera (pid 7695) has died: prcp FGS
Scheduling restart of crashed service .../.StreamingService in 1000ms
Start proc 9520 ... for service .../StreamingService
```

## Changes

- `onStartCommand` starts the server when the `Intent` is null. `startStreamingServer()` already early-returns when the socket is open, so this is safe to reach on any path.
- The accept loop is supervised: if it ends without anyone asking it to, a restart is scheduled after a short delay. `stopServer()` and every new start bump `serverGeneration`, so an unrequested exit is just the loop finishing with its own generation still current — no new state needed to tell the two apart.

The retry is gated on the socket having actually been published, so a server that never bound (bad certificate, port already in use) cannot retry-storm. A failed retry ends the same way and schedules the next one, which gives a fixed-interval retry for as long as the failure lasts.

## Testing

Built and running on the affected device (armeabi-v7a, Android 10). Verified the server comes back on its own after the process is killed, and that `/video/snapshot` and `/video/mjpeg` serve normally afterwards.